### PR TITLE
Compiling errors resolved and atoms sorted

### DIFF
--- a/sort.v
+++ b/sort.v
@@ -1,0 +1,27 @@
+module main
+
+fn partition(nums mut []string, low, high int) int {
+    pivot := nums[high]
+    mut i := low - 1
+
+    for j := low; j <= high - 1; j++ {
+        if nums[j] < pivot {
+            i++
+            temp := nums[i]
+            nums[i] = nums[j]
+            nums[j] = temp
+        }
+    }
+    temp := nums[i + 1]
+    nums[i + 1] = nums[high]
+    nums[high] = temp
+    return i + 1
+}
+
+fn quicksort(nums mut []string , low, high int) {
+    if low < high {
+        pi := partition(mut nums, low, high)
+        quicksort(mut nums, low, pi - 1)
+        quicksort(mut nums, pi + 1, high)
+    }
+}

--- a/vlogsolv.v
+++ b/vlogsolv.v
@@ -3,10 +3,10 @@ module main
 import os
 
 fn main() {
-	mut expr := ""
+	mut expr := ''
 	for i, s in os.args {
 		if i == 0 { continue } // Skip executable name
-		mut trim := ""
+		mut trim := ''
 		for _, c in s { if c != ` ` { trim += c.str() } }
 		expr += trim
 	}
@@ -34,7 +34,7 @@ fn main() {
 	println(row)
 
 	lastrow := row
-	row = ""
+	row = ''
 	for _, c in lastrow {
 		if c == `|` {
 			row += '+'

--- a/vlogsolv.v
+++ b/vlogsolv.v
@@ -74,6 +74,7 @@ fn get_atoms(exp string) []string {
 		}
 	}
 
+	quicksort(mut result, 0, (result.len - 1))
 	return result
 }
 


### PR DESCRIPTION
Errors occuring while compiling the program with `v .` resolved.
No more, `invalid character ", use ' to denote strings` error.

Edit: gives this error on v 0.1.19


Atoms sorted.
Closes #2 